### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/inv2004/coinbase-pro-rs"
 description = "Coinbase pro client for Rust"
 license = "MIT/Apache-2.0"
 readme = "README.md"
-categories = [ "api-bindings" ]
+categories = [ "api-bindings", "cryptography::cryptocurrencies" ]
 keywords = [ "exchange", "coinbase", "bitcoin", "websocket" ]
 
 [dependencies]


### PR DESCRIPTION
In the next release, crates.io will have a category for cryptocurrency-related crates:

https://github.com/rust-lang/crates.io/pull/1674