### PR TITLE
Update private.rs

### DIFF
--- a/src/structs/private.rs
+++ b/src/structs/private.rs
@@ -100,9 +100,10 @@ impl<'a> From<&'a AccountHistoryDetails> for AccountHistoryType {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AccountHolds {
     pub id: Uuid,
-    pub account_id: Uuid,
+    // pub id: Uuid, 
     pub created_at: DateTime,
-    pub updated_at: DateTime,
+    // pub updated_at: DateTime, 
+    #[serde(deserialize_with = "f64_from_string")]
     pub amount: f64,
     #[serde(rename = "type")]
     pub _type: AccountHoldsType,


### PR DESCRIPTION
added missing attribute for f64 fields (#[serde(deserialize_with = "f64_from_string")]) to prevent error: "invalid type: string \"13.0000000000000000\", expected f64"

changed account_id field for AccountHolds struct to id, which matches what is being reported by the API. 

removed struct field which was missing from API results: updated_at.