### PR TITLE
Private API Extensions

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -239,6 +239,7 @@ impl<A> Private<A> {
         price: f64,
         post_only: bool,
         time_in_force: Option<reqs::OrderTimeInForce>,
+        client_oid: Option<Uuid>
     ) -> A::Result
     where
         A: Adapter<Order> + 'static,
@@ -250,6 +251,7 @@ impl<A> Private<A> {
             price,
             post_only,
             time_in_force,
+            client_oid,
         ))
     }
 
@@ -262,6 +264,7 @@ impl<A> Private<A> {
         price: f64,
         post_only: bool,
         time_in_force: Option<reqs::OrderTimeInForce>,
+        client_oid: Option<Uuid>
     ) -> A::Result
     where
         A: Adapter<Order> + 'static,
@@ -273,25 +276,26 @@ impl<A> Private<A> {
             price,
             post_only,
             time_in_force,
+            client_oid,
         ))
     }
 
     /// **Buy market**
     /// Makes Buy marker order
-    pub fn buy_market(&self, product_id: &str, size: f64) -> A::Result
+    pub fn buy_market(&self, product_id: &str, size: f64, client_oid: Option<Uuid>) -> A::Result
     where
         A: Adapter<Order> + 'static,
     {
-        self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Buy, size))
+        self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Buy, size, client_oid))
     }
 
     /// **Sell market**
     /// Makes Sell marker order
-    pub fn sell_market(&self, product_id: &str, size: f64) -> A::Result
+    pub fn sell_market(&self, product_id: &str, size: f64, client_oid: Option<Uuid>) -> A::Result
     where
         A: Adapter<Order> + 'static,
     {
-        self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Sell, size))
+        self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Sell, size, client_oid))
     }
 
     //    pub fn buy<'a>(&self) -> OrderBuilder<'a> {}    // TODO: OrderBuilder

--- a/src/structs/reqs.rs
+++ b/src/structs/reqs.rs
@@ -1,6 +1,9 @@
+use uuid::Uuid;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Order<'a> {
     side: OrderSide,
+    client_oid: Option<Uuid>,
     product_id: &'a str,
     #[serde(flatten)]
     _type: OrderType,
@@ -41,9 +44,15 @@ pub enum MarketType {
 }
 
 impl<'a> Order<'a> {
-    pub fn market(product_id: &'a str, side: OrderSide, size: f64) -> Self {
+    pub fn market(
+        product_id: &'a str,
+        side: OrderSide,
+        size: f64,
+        client_oid: Option<Uuid>
+    ) -> Self {
         Order {
             product_id,
+            client_oid,
             side,
             _type: OrderType::Market {
                 _type: MarketType::Size { size },
@@ -59,9 +68,11 @@ impl<'a> Order<'a> {
         price: f64,
         post_only: bool,
         time_in_force: Option<OrderTimeInForce>,
+        client_oid: Option<Uuid>,
     ) -> Self {
         Order {
             product_id,
+            client_oid,
             side,
             _type: OrderType::Limit {
                 price,

--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -6,6 +6,7 @@ use utils::f64_from_string;
 use utils::f64_nan_from_string;
 use utils::f64_opt_from_string;
 use utils::usize_from_string;
+use utils::uuid_opt_from_string;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -265,6 +266,8 @@ pub enum Received {
         product_id: String,
         sequence: usize,
         order_id: Uuid,
+        #[serde(deserialize_with = "uuid_opt_from_string")]
+        client_oid: Option<Uuid>,
         #[serde(deserialize_with = "f64_from_string")]
         size: f64,
         #[serde(deserialize_with = "f64_from_string")]
@@ -276,6 +279,7 @@ pub enum Received {
         product_id: String,
         sequence: usize,
         order_id: Uuid,
+        client_oid: Option<Uuid>,
         #[serde(default)]
         #[serde(deserialize_with = "f64_opt_from_string")]
         funds: Option<f64>,

--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -342,6 +342,12 @@ pub struct Match {
     #[serde(deserialize_with = "f64_from_string")]
     pub price: f64,
     pub side: super::reqs::OrderSide,
+    pub user_id: Option<String>,
+    pub profile_id: Option<Uuid>,
+    pub taker_user_id: Option<String>,
+    pub taker_profile_id: Option<Uuid>,
+    pub maker_user_id: Option<String>,
+    pub maker_profile_id: Option<Uuid>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::fmt;
+use uuid::Uuid;
+use std::str::FromStr;
 
 struct F64InQuotes;
 
@@ -37,6 +39,18 @@ where
     D: Deserializer<'de>,
 {
     d.deserialize_any(F64InQuotes).map(Some).or(Ok(None))
+}
+
+pub fn uuid_opt_from_string<'de, D>(d: D) -> Result<Option<Uuid>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    if s.len() == 0 {
+        Ok(None)
+    } else {
+        Uuid::from_str(&s).map_err(de::Error::custom).map(Some)
+    }
 }
 
 pub fn f64_nan_from_string<'de, D>(d: D) -> Result<f64, D::Error>

--- a/tests/private.rs
+++ b/tests/private.rs
@@ -87,7 +87,7 @@ fn test_get_account_holds() {
 #[test]
 fn test_new_order_ser() {
     delay();
-    let order = reqs::Order::market("BTC-UST", reqs::OrderSide::Buy, 1.1);
+    let order = reqs::Order::market("BTC-UST", reqs::OrderSide::Buy, 1.1, None);
     let str = serde_json::to_string(&order).unwrap();
     assert_eq!(
         vec![0],
@@ -100,12 +100,12 @@ fn test_new_order_ser() {
 fn test_set_order_limit() {
     delay();
     let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None).unwrap();
+    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None, None).unwrap();
     let str = format!("{:?}", order);
     assert!(str.contains("side: Buy"));
     assert!(str.contains("_type: Limit {"));
     let order = client
-        .sell_limit("BTC-USD", 0.001, 100000.0, true, None)
+        .sell_limit("BTC-USD", 0.001, 100000.0, true, None, None)
         .unwrap();
     let str = format!("{:?}", order);
     assert!(str.contains("side: Sell"));
@@ -125,6 +125,7 @@ fn test_set_order_limit_gtc() {
             Some(reqs::OrderTimeInForce::GTT {
                 cancel_after: reqs::OrderTimeInForceCancelAfter::Min,
             }),
+            None
         ).unwrap();
     //        let order = client.buy("BTC-USD", 1.0).limit(1.0, 1.12).post_only().gtt(min).send()
     let str = format!("{:?}", order);
@@ -136,11 +137,11 @@ fn test_set_order_limit_gtc() {
 fn test_set_order_market() {
     delay();
     let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-    let order = client.buy_market("BTC-USD", 0.001).unwrap();
+    let order = client.buy_market("BTC-USD", 0.001, None).unwrap();
     let str = format!("{:?}", order);
     assert!(str.contains("side: Buy"));
     assert!(str.contains("_type: Market {"));
-    let order = client.sell_market("BTC-USD", 0.001).unwrap();
+    let order = client.sell_market("BTC-USD", 0.001, None).unwrap();
     let str = format!("{:?}", order);
     assert!(str.contains("side: Sell"));
     assert!(str.contains("_type: Market {"));
@@ -151,7 +152,7 @@ fn test_set_order_market() {
 fn test_cancel_order() {
     delay();
     let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None).unwrap();
+    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None, None).unwrap();
     let res = client.cancel_order(order.id).unwrap();
     assert_eq!(order.id, res);
 }
@@ -160,8 +161,8 @@ fn test_cancel_order() {
 fn test_cancel_all() {
     delay();
     let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-    let order1 = client.buy_limit("BTC-USD", 1.0, 1.12, true, None).unwrap();
-    let order2 = client.buy_limit("BTC-USD", 1.0, 1.12, true, None).unwrap();
+    let order1 = client.buy_limit("BTC-USD", 1.0, 1.12, true, None, None).unwrap();
+    let order2 = client.buy_limit("BTC-USD", 1.0, 1.12, true, None, None).unwrap();
     let res = client.cancel_all(Some("BTC-USD")).unwrap();
     assert!(res.iter().find(|x| **x == order1.id).is_some());
     assert!(res.iter().find(|x| **x == order2.id).is_some());
@@ -182,7 +183,7 @@ fn test_get_orders() {
 fn test_get_order() {
     delay();
     let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None).unwrap();
+    let order = client.buy_limit("BTC-USD", 1.0, 1.12, true, None, None).unwrap();
     let order_res = client.get_order(order.id).unwrap();
     assert_eq!(order.id, order_res.id);
 }

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -252,7 +252,7 @@ fn test_user() {
         let str = format!("{:?}", msg);
         if str.contains("Subscriptions") {
             let client: Private<ASync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
-            let res = client.buy_limit("BTC-USD", 0.001, 100.0, true, None)
+            let res = client.buy_limit("BTC-USD", 0.001, 100.0, true, None, None)
                 .and_then(|_| {
                     Ok(())
                 })


### PR DESCRIPTION
Thanks for your work on this repo!  This PR has two additions.

1) It extends the WS Match struct to include fields that come into the message when you are authenticated which makes it easier to figure out whether you were a maker or a taker.

2) It allows sending the `client_oid` field with new orders which can be used to track an order when it comes in via the websocket (specifically via the `Received` message). Without this I had to do a bunch of nasty locking. 

2 is definitely a bit more abrasive of a change (it breaks the ordering APIs). Ultimately we might want to consider something like an order builder rather than all of the different functions. eg. something like:

```rust
let order = Order::buy()
  .limit(1000.0)
  .client_oid(Uuid::new_v4())
  .time_in_force(OrderTimeInForce::FOK);

client.place_order(order);
```

This would let us continue to extend the API without (as many) breaking changes. It also saves the current 5-6 argument order methods that we have currently.

Either way, let me know if you want me to break apart the pull request or need any changes.

Cheers!