### PR TITLE
fix: visibility of reqs::Order constructors

### DIFF
--- a/src/structs/reqs.rs
+++ b/src/structs/reqs.rs
@@ -44,7 +44,7 @@ pub enum MarketType {
 }
 
 impl<'a> Order<'a> {
-    pub(crate) fn market(
+    pub fn market(
         product_id: &'a str,
         side: OrderSide,
         size: f64,
@@ -68,7 +68,7 @@ impl<'a> Order<'a> {
         Self::market(product_id, OrderSide::Sell, size)
     }
 
-    pub(crate) fn limit(
+    pub fn limit(
         product_id: &'a str,
         side: OrderSide,
         size: f64,


### PR DESCRIPTION
Please forgive me if this isn't *actually* necessary. I believe that `pub(crate)` is ambiguous on struct constructors and doesn't actually cause these functions to be exposed publicly.

If I'm incorrect here, please excuse this PR and let me know the correct syntax to create a request using `market` or `limit` constructors from an external package.