### PR TITLE
feat: stop methods for order builder

### DIFF
--- a/src/structs/private.rs
+++ b/src/structs/private.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use super::DateTime;
 use utils::datetime_from_string;
 use utils::usize_from_string;
+use super::reqs::OrderStop;
 
 // Private
 
@@ -139,6 +140,8 @@ pub struct Order {
     pub executed_value: f64,
     pub status: OrderStatus,
     pub settled: bool,
+    #[serde(flatten)]
+    pub stop: Option<OrderStop>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/structs/reqs.rs
+++ b/src/structs/reqs.rs
@@ -103,6 +103,19 @@ impl<'a> Order<'a> {
         Order{client_oid, .. self }
     }
 
+    pub fn stop(self, price: f64, stop_type: OrderStopType) -> Self {
+        let stop = Some(OrderStop { stop_price: price, _type: stop_type });
+        Order{stop, .. self}
+    }
+
+    pub fn stop_loss(self, price: f64) -> Self {
+        self.stop(price, OrderStopType::Loss)
+    }
+
+    pub fn stop_entry(self, price: f64) -> Self {
+        self.stop(price, OrderStopType::Entry)
+    }
+
     pub fn time_in_force(self, time_in_force: OrderTimeInForce) -> Self {
         match self._type {
             OrderType::Limit {price, size, post_only, ..} => {
@@ -135,9 +148,9 @@ pub enum OrderTimeInForceCancelAfter {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct OrderStop {
     stop_price: f64,
+    #[serde(rename = "stop")]
     _type: OrderStopType,
 }
 
@@ -164,8 +177,10 @@ mod tests {
 
         let o = Order::buy_limit("BTC-USD", 10.0, 100.0, true)
             .client_oid(Uuid::nil())
+            .stop_loss(99.0)
             .time_in_force(OrderTimeInForce::GTC);
         assert!(o.client_oid.is_some());
+        assert!(o.stop.is_some());
 
         match &o._type {
             OrderType::Limit {time_in_force: Some(OrderTimeInForce::GTC), ..} => assert!(true),

--- a/tests/private.rs
+++ b/tests/private.rs
@@ -128,6 +128,23 @@ fn test_set_order_limit_gtc() {
 }
 
 #[test]
+fn test_set_order_stop() {
+    delay();
+    let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
+
+    let order = reqs::Order::buy_limit("BTC-USD", 1.0, 1.12, false)
+        .stop_entry(0.8)
+        .time_in_force(OrderTimeInForce::GTT {cancel_after: OrderTimeInForceCancelAfter::Min});
+
+    let str = serde_json::to_string(&order).unwrap();
+    print!("{:?}", str);
+
+    let order = client.set_order(order).unwrap();
+    //        let order = client.buy("BTC-USD", 1.0).limit(1.0, 1.12).post_only().gtt(min).send()
+    assert!(order.stop.is_some());
+}
+
+#[test]
 #[ignore] // sandbox price is too high
 fn test_set_order_market() {
     delay();


### PR DESCRIPTION
Adds `stop_loss`, `stop`, and `stop_entry` methods to the order builder
API.

It also fixes the serialization of stop orders and adds it to the response.

Note: GDAX's sandbox API is a bit wonky right now so I was getting some failed tests. I didn't dig too far.