### PR TITLE
Check for presence of Zulu time symbol at end of datetime string prior to appending it and subsequently parsing.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,5 +73,9 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(d)?;
-    (s + "Z").parse().map_err(de::Error::custom)
+    if s.ends_with("Z") {
+        s.parse().map_err(de::Error::custom)
+    } else{ 
+        (s + "Z").parse().map_err(de::Error::custom)
+    }
 }


### PR DESCRIPTION
Of recent, when making orders that have a time_in_force parameter of _GTT_, there are errors when parsing the json representation of that order. The reason for this is that the _"expire_time"_ in the json representation of the order has a format such as "2019-09-07T07:30:50.22512Z" with the Zulu symbol already at the end - and the utils datetime_from_string also goes ahead to append a Zulu symbol at the end of datetime. 

This change adds a check so that the Zulu symbol is only added if it is not already there.