### PR TITLE
product_id getter & test enhancement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ tokio-compat-02 = "0.1"
 tokio-tungstenite = { version = "0.12.0", features = ["tls"] }
 url = "2.1.0"
 uuid = { version = "0.8.1", features = [ "serde", "v4" ] }
+
+[dev-dependencies]
+serial_test = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 categories = [ "api-bindings", "cryptography::cryptocurrencies" ]
 keywords = [ "exchange", "coinbase", "bitcoin", "websocket" ]
 
+[features]
+latency-tests = []
+
 [dependencies]
 base64 = "0.10.0"
 bytes = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ hyper = { version = "0.13.9", features = ["stream"] }
 hyper-tls = "0.4.3"
 log = "0.4.4"
 pretty_env_logger = "0.3.0"
-serde = "1.0.101"
-serde_derive = "1.0.101"
-serde_json = "1.0.41"
+serde = { version = "1", features = ["derive"]}
+serde_derive = "1"
+serde_json = "1"
 sha2 = "0.8.0"
 thiserror = "1.0.22"
 time = "0.1.41"

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -68,6 +68,7 @@ mod tests {
     use futures::{future, TryFutureExt};
 
     #[test]
+    #[serial]
     fn test_sync() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -80,6 +81,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_async() {
         delay();
         let client: Public<ASync> = Public::new(SANDBOX_URL);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,10 @@ pub use crate::private::Private;
 pub use crate::public::Public;
 pub use crate::wsfeed::WSFeed;
 
+#[cfg(test)]
+#[macro_use]
+extern crate serial_test;
+
 pub type Result<T> = std::result::Result<T, CBError>;
 
 /// https://api.pro.coinbase.com

--- a/src/private.rs
+++ b/src/private.rs
@@ -416,6 +416,7 @@ mod tests {
     static PASSPHRASE: &str = "sandbox";
 
     #[test]
+    #[serial]
     fn test_get_accounts() {
         delay();
         let client: Private<crate::Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -425,6 +426,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_account() {
         delay();
         //        super::super::pretty_env_logger::init_custom_env("RUST_LOG=trace");
@@ -446,6 +448,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_account_hist() {
         delay();
         //        super::super::pretty_env_logger::init_custom_env("RUST_LOG=trace");
@@ -463,6 +466,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore]
     fn test_get_account_holds() {
         delay();
@@ -483,7 +487,6 @@ mod tests {
 
     #[test]
     fn test_new_order_ser() {
-        delay();
         let order = reqs::Order::buy_market("BTC-UST", 1.1);
         let str = serde_json::to_string(&order).unwrap();
         assert_eq!(
@@ -493,6 +496,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore] // sandbox price is too high
     fn test_set_order_limit() {
         delay();
@@ -508,6 +512,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_set_order_limit_gtc() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -525,6 +530,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_set_order_stop() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -543,6 +549,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore] // sandbox price is too high
     fn test_set_order_market() {
         delay();
@@ -559,6 +566,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cancel_order() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -569,6 +577,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cancel_all() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -580,6 +589,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore]
     fn test_get_orders() {
         delay();
@@ -591,6 +601,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_order() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -600,6 +611,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_fills() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
@@ -611,6 +623,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore]
     fn test_get_trailing_volume() {
         delay();
@@ -621,6 +634,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_pub() {
         delay();
         let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);

--- a/src/public.rs
+++ b/src/public.rs
@@ -312,6 +312,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "latency-tests"), ignore)] // region & opt-level dependent
     #[serial]
     fn test_check_latency() {
         delay();
@@ -321,12 +322,11 @@ mod tests {
         let _ = client.get_time().unwrap();
         let time = time.elapsed().subsec_millis();
         dbg!(time);
-        if time > 150 {
-            panic!("{} > 100", time);
-        }
+        assert!(time <= 150, "too slow")
     }
 
     #[tokio::test]
+    #[cfg_attr(not(feature = "latency-tests"), ignore)] // region & opt-level dependent
     #[serial]
     async fn test_check_latency_async_block_on() {
         delay();
@@ -336,10 +336,11 @@ mod tests {
         client.get_time().await.unwrap();
         let time = time.elapsed().subsec_millis();
         dbg!(time);
-        assert!(time <= 150)
+        assert!(time <= 150, "too slow")
     }
 
     #[tokio::test]
+    #[cfg_attr(not(feature = "latency-tests"), ignore)] // region & opt-level dependent
     #[serial]
     async fn test_check_latency_async() {
         delay();
@@ -350,7 +351,7 @@ mod tests {
         let time = time.elapsed().subsec_millis();
 
         dbg!(time);
-        assert!(time <= 150, "Fast enough");
+        assert!(time <= 150, "too slow")
     }
 
     //    #[test]

--- a/src/public.rs
+++ b/src/public.rs
@@ -1,7 +1,6 @@
 //! Contains structure which provides access to Public section of Coinbase api
 
 use chrono::SecondsFormat;
-use futures::future;
 use futures_util::future::TryFutureExt;
 use hyper::client::HttpConnector;
 use hyper::{body::to_bytes, Body, Client, Request, Uri};
@@ -189,7 +188,6 @@ mod tests {
     use super::*;
     use crate::*;
     use chrono::prelude::*;
-    use futures::future::{self, FutureExt};
     use std::time::Instant;
 
     static DELAY_TIMEOUT: u64 = 200;
@@ -199,6 +197,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_time() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -211,6 +210,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_products() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -220,6 +220,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[ignore] // rate limits
     fn test_get_book() {
         delay();
@@ -241,6 +242,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_ticker() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -252,6 +254,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_trades() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -262,6 +265,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_candles() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -276,6 +280,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_stats24h() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -288,6 +293,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_currencies() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -306,6 +312,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_check_latency() {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
@@ -320,6 +327,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_check_latency_async_block_on() {
         delay();
         let client: Public<ASync> = Public::new(SANDBOX_URL);
@@ -332,6 +340,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_check_latency_async() {
         delay();
         let client: Public<ASync> = Public::new(SANDBOX_URL);

--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -120,6 +120,15 @@ pub enum Level2 {
     },
 }
 
+impl Level2 {
+    pub fn product_id(&self) -> &str {
+        match self {
+            Level2::Snapshot { product_id, .. } => product_id,
+            Level2::L2update { product_id, .. } => product_id,
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct Level2SnapshotRecord {
     #[serde(deserialize_with = "f64_from_string")]
@@ -176,6 +185,13 @@ impl Ticker {
         match self {
             Ticker::Full { time, .. } => Some(time),
             Ticker::Empty { .. } => None,
+        }
+    }
+
+    pub fn product_id(&self) -> &str {
+        match self {
+            Ticker::Full { product_id, .. } => product_id,
+            Ticker::Empty { product_id, .. } => product_id,
         }
     }
 
@@ -248,6 +264,19 @@ impl Full {
             Full::Match(Match { sequence, .. }) => Some(sequence),
             Full::Change(Change { sequence, .. }) => Some(sequence),
             Full::Activate(Activate { .. }) => None,
+        }
+    }
+
+    pub fn product_id(&self) -> &str {
+        match self {
+            Full::Received(Received::Limit { product_id, .. }) => product_id,
+            Full::Received(Received::Market { product_id, .. }) => product_id,
+            Full::Open(Open { product_id, .. }) => product_id,
+            Full::Done(Done::Limit { product_id, .. }) => product_id,
+            Full::Done(Done::Market { product_id, .. }) => product_id,
+            Full::Match(Match { product_id, .. }) => product_id,
+            Full::Change(Change { product_id, .. }) => product_id,
+            Full::Activate(Activate { product_id, .. }) => product_id,
         }
     }
 }

--- a/src/wsfeed.rs
+++ b/src/wsfeed.rs
@@ -52,7 +52,7 @@ impl WSFeed {
     // Constructor for extended subcription via Subscribe structure
     pub fn new_with_sub(
         uri: &str,
-        subsribe: Subscribe,
+        subscribe: Subscribe,
     ) -> impl Stream<Item = Result<Message, CBError>> {
         let url = Url::parse(uri).unwrap();
 
@@ -62,10 +62,10 @@ impl WSFeed {
                 log::debug!("WebSocket handshake has been successfully completed");
                 let (mut sink, stream) = ws_stream.split();
 
-                let subsribe = serde_json::to_string(&subsribe).unwrap();
+                let subscribe = serde_json::to_string(&subscribe).unwrap();
 
                 let ret = sink
-                    .send(TMessage::Text(subsribe))
+                    .send(TMessage::Text(subscribe))
                     .map_err(|e| CBError::Websocket(WSError::Send(e)))
                     .await;
                 log::debug!("subsription sent");

--- a/src/wsfeed.rs
+++ b/src/wsfeed.rs
@@ -121,7 +121,6 @@ impl WSFeed {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::{utils::delay, WSFeed, WS_SANDBOX_URL, WS_URL};
     use futures::{
@@ -140,7 +139,6 @@ mod tests {
 
     #[test]
     fn test_subscribe() {
-        delay();
         let s = Subscribe {
             _type: SubscribeCmd::Subscribe,
             product_ids: vec!["BTC-USD".to_string()],
@@ -163,7 +161,6 @@ mod tests {
 
     #[test]
     fn test_subscribe_auth() {
-        delay();
         let s = Subscribe {
             _type: SubscribeCmd::Subscribe,
             product_ids: vec!["BTC-USD".to_string()],
@@ -190,6 +187,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_subscription() {
         delay();
         let stream = WSFeed::new(WS_SANDBOX_URL, &["BTC-USD"], &[ChannelType::Heartbeat]);
@@ -213,6 +211,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_heartbeat() {
         delay();
         let found = Arc::new(AtomicBool::new(false));
@@ -235,6 +234,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_ticker() {
         delay();
         let found = Arc::new(AtomicBool::new(false));
@@ -259,6 +259,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_level2() {
         delay();
         let found_snapshot = Arc::new(AtomicBool::new(false));
@@ -296,6 +297,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_match() {
         delay();
         let found_match = Arc::new(AtomicBool::new(false));
@@ -331,6 +333,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_full() {
         delay();
         let found_received_limit = Arc::new(AtomicBool::new(false));
@@ -389,6 +392,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_user() {
         use crate::{ASync, Private, WSError, SANDBOX_URL};
 

--- a/src/wsfeed.rs
+++ b/src/wsfeed.rs
@@ -333,6 +333,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     #[serial]
     fn test_full() {
         delay();
@@ -354,7 +355,7 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             stream
-                .take(3000)
+                .take(5000)
                 .try_for_each(move |msg| {
                     let str = format!("{:?}", msg);
                     if str.starts_with(


### PR DESCRIPTION
Hello maintainer,
I made three minor changes to coinbase-pro-rs.

1. product_id getter for enum Message's variants
2. serialize rate limited tests. So that they always be run one by one. 
(because forgetting "test-threads=1" could lead to our IP being banned)
3. ignore some uncertain tests 
latency test's success depends on region & optimization level
full_book test can be fail in normal situation

