### PR TITLE
Add support for market order with desired amount in base currency, eg BTC if product_id is BTC-USD

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -260,7 +260,7 @@ impl<A> Private<A> {
     }
 
     /// **Buy market**
-    /// Makes Buy marker order
+    /// Makes Buy market order with desired amount in base currency, eg: BTC if product_id is BTC-USD
     pub fn buy_market(&self, product_id: &str, size: f64) -> A::Result
     where
         A: Adapter<Order> + 'static,
@@ -268,13 +268,37 @@ impl<A> Private<A> {
         self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Buy, size))
     }
 
+    /// Makes Buy market order with desired amount in quoted currency, eg: USD if product_id is BTC-USD
+    pub fn buy_market_funds(&self, product_id: &str, funds: f64) -> A::Result
+    where
+        A: Adapter<Order> + 'static,
+    {
+        self.set_order(reqs::Order::market_funds(
+            product_id,
+            reqs::OrderSide::Buy,
+            funds,
+        ))
+    }
+
     /// **Sell market**
-    /// Makes Sell marker order
+    /// Makes Sell market order with desired amount in base currency, eg: BTC if product_id is BTC-USD
     pub fn sell_market(&self, product_id: &str, size: f64) -> A::Result
     where
         A: Adapter<Order> + 'static,
     {
         self.set_order(reqs::Order::market(product_id, reqs::OrderSide::Sell, size))
+    }
+
+    /// Makes Sell market order with desired amount in quoted currency, eg: USD if product_id is BTC-USD
+    pub fn sell_market_funds(&self, product_id: &str, funds: f64) -> A::Result
+    where
+        A: Adapter<Order> + 'static,
+    {
+        self.set_order(reqs::Order::market_funds(
+            product_id,
+            reqs::OrderSide::Sell,
+            funds,
+        ))
     }
 
     //    pub fn buy<'a>(&self) -> OrderBuilder<'a> {}    // TODO: OrderBuilder
@@ -501,6 +525,27 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_buy_market_funds() {
+        delay();
+        let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
+        let order = client.buy_market_funds("BTC-USD", 10.0).unwrap();
+        let str = format!("{:?}", order);
+        assert!(str.contains("side: Buy"));
+        assert!(str.contains("_type: Market { size: 0.0, funds: "));
+    }
+
+    #[test]
+    #[serial]
+    fn test_sell_market_funds() {
+        delay();
+        let client: Private<Sync> = Private::new(SANDBOX_URL, KEY, SECRET, PASSPHRASE);
+        let order = client.sell_market_funds("BTC-USD", 10.0).unwrap();
+        let str = format!("{:?}", order);
+        assert!(str.contains("side: Sell"));
+        assert!(str.contains("_type: Market { size: 0.0, funds: "));
+    }
+
+    #[test]
     #[ignore] // sandbox price is too high
     fn test_set_order_limit() {
         delay();

--- a/src/public.rs
+++ b/src/public.rs
@@ -115,6 +115,13 @@ impl<A> Public<A> {
         self.get_pub("/products")
     }
 
+    pub fn get_product(&self, product_id: &str) -> A::Result
+    where
+        A: Adapter<Product> + 'static,
+    {
+        self.get_pub(&format!("/products/{}", product_id))
+    }
+
     pub fn get_book<T>(&self, product_id: &str) -> A::Result
     where
         A: Adapter<Book<T>> + 'static,
@@ -214,6 +221,16 @@ mod tests {
         delay();
         let client: Public<Sync> = Public::new(SANDBOX_URL);
         let products = client.get_products().unwrap();
+        let str = format!("{:?}", products);
+        assert!(str.contains("{ id: \"BTC-USD\""));
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_product() {
+        delay();
+        let client: Public<Sync> = Public::new(SANDBOX_URL);
+        let products = client.get_product("BTC-USD").unwrap();
         let str = format!("{:?}", products);
         assert!(str.contains("{ id: \"BTC-USD\""));
     }

--- a/src/structs/public.rs
+++ b/src/structs/public.rs
@@ -22,14 +22,27 @@ pub struct Currency {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Product {
     pub id: String,
+    pub display_name: String,
     pub base_currency: String,
     pub quote_currency: String,
+    #[serde(deserialize_with = "f64_from_string")]
+    pub base_increment: f64,
+    #[serde(deserialize_with = "f64_from_string")]
+    pub quote_increment: f64,
     #[serde(deserialize_with = "f64_from_string")]
     pub base_min_size: f64,
     #[serde(deserialize_with = "f64_from_string")]
     pub base_max_size: f64,
     #[serde(deserialize_with = "f64_from_string")]
-    pub quote_increment: f64,
+    pub min_market_funds: f64,
+    #[serde(deserialize_with = "f64_from_string")]
+    pub max_market_funds: f64,
+    pub status: String,
+    pub status_message: String,
+    pub cancel_only: bool,
+    pub limit_only: bool,
+    pub post_only: bool,
+    pub trading_disabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/structs/reqs.rs
+++ b/src/structs/reqs.rs
@@ -67,6 +67,26 @@ impl<'a> Order<'a> {
         Self::market(product_id, OrderSide::Sell, size)
     }
 
+    pub fn market_funds<T: Into<Cow<'a, str>>>(product_id: T, side: OrderSide, funds: f64) -> Self {
+        Order {
+            product_id: product_id.into(),
+            client_oid: None,
+            side,
+            _type: OrderType::Market {
+                _type: MarketType::Funds { funds },
+            },
+            stop: None,
+        }
+    }
+
+    pub fn buy_market_funds<T: Into<Cow<'a, str>>>(product_id: T, funds: f64) -> Self {
+        Self::market_funds(product_id, OrderSide::Buy, funds)
+    }
+
+    pub fn sell_market_funds<T: Into<Cow<'a, str>>>(product_id: T, funds: f64) -> Self {
+        Self::market_funds(product_id, OrderSide::Sell, funds)
+    }
+
     pub fn limit<T: Into<Cow<'a, str>>>(
         product_id: T,
         side: OrderSide,


### PR DESCRIPTION
This diff also adds some missing field in the Product struct