### PR TITLE
apply Send trait bound

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 script:
   - cargo build --all
-  - cargo test --all --no-fail-fast -- --test-threads=1
+  - cargo test --all --no-fail-fast

--- a/README.md
+++ b/README.md
@@ -111,5 +111,4 @@ by request
 <https://github.com/inv2004/orderbook-rs>
 
 ### Tests
-cargo test -- --test-threads=1
-// to avoid "Rate limit exceeded" error
+cargo test 

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -10,7 +10,7 @@ pub trait Adapter<T> {
     type Result: Sized;
     fn process<F>(&self, f: F) -> Self::Result
     where
-        F: Future<Output = Result<T, CBError>> + 'static;
+        F: Future<Output = Result<T, CBError>> + Send + 'static;
 }
 
 pub trait AdapterNew: Sized {
@@ -34,7 +34,7 @@ where
     type Result = Result<T, CBError>;
     fn process<F>(&self, f: F) -> Self::Result
     where
-        F: Future<Output = Result<T, CBError>> + 'static,
+        F: Future<Output = Result<T, CBError>> + Send + 'static,
     {
         self.0.borrow_mut().block_on(f)
     }
@@ -50,11 +50,11 @@ impl AdapterNew for ASync {
 }
 
 impl<T> Adapter<T> for ASync {
-    type Result = Pin<Box<dyn Future<Output = Result<T, CBError>>>>;
+    type Result = Pin<Box<dyn Future<Output = Result<T, CBError>> + Send>>;
 
     fn process<F>(&self, f: F) -> Self::Result
     where
-        F: Future<Output = Result<T, CBError>> + 'static,
+        F: Future<Output = Result<T, CBError>> + Send + 'static,
     {
         Box::pin(f)
     }

--- a/src/public.rs
+++ b/src/public.rs
@@ -370,6 +370,13 @@ mod tests {
         assert!(time <= 150, "too slow")
     }
 
+    #[tokio::test]
+    #[ignore]
+    async fn send_test() {
+        let client: Public<ASync> = Public::new(SANDBOX_URL);
+        tokio::spawn(client.get_products()).await;
+    }
+
     //    #[test]
     //    fn test_tls() { // it hangs
     //        let https = HttpsConnector::new(4).unwrap();

--- a/src/public.rs
+++ b/src/public.rs
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore] // checks compilation only
     async fn send_test() {
         let client: Public<ASync> = Public::new(SANDBOX_URL);
         tokio::spawn(client.get_products()).await;


### PR DESCRIPTION
Adapter need Send trait bound, if there is no Send trait bound for F,
we can't call await on Adapter's F in different thread.
(e.g. "send_test" test doesn't compile on previous version of code.)