### PR TITLE
wsfeed: include maker/taker fee rate in Match record

### DIFF
--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -384,8 +384,16 @@ pub struct Match {
     pub side: super::reqs::OrderSide,
     pub taker_user_id: Option<String>,
     pub taker_profile_id: Option<Uuid>,
+    #[serde(default)]
+    #[serde(deserialize_with = "f64_opt_from_string")]
+    pub taker_fee_rate: Option<f64>,
+
     pub maker_user_id: Option<String>,
     pub maker_profile_id: Option<Uuid>,
+    #[serde(default)]
+    #[serde(deserialize_with = "f64_opt_from_string")]
+    pub maker_fee_rate: Option<f64>,
+
     pub user_id: Option<String>,
     #[serde(default)]
     #[serde(deserialize_with = "uuid_opt_from_string")]


### PR DESCRIPTION
`Match::maker_fee_rate` and `Match::taker_fee_rate` are optionally included, similar to `maker_user_id`, on self-involved matches when authenticated. The [Coinbase Pro docs](https://docs.pro.coinbase.com/#the-full-channel) outline this.