### PR TITLE
Remove serde_derive: it's no longer unnecessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ hyper-tls = "0.5.0"
 log = "0.4.4"
 pretty_env_logger = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.9.2"
 thiserror = "1.0.22"


### PR DESCRIPTION
`features = ["derive"]` on the `serde` dependency superseded the separate `serde_derive` crate. It it no longer necessary.