### PR TITLE
Add time field for L2update message

### DIFF
--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -72,6 +72,7 @@ pub(crate) enum InputMessage {
     L2update {
         product_id: String,
         changes: Vec<Level2UpdateRecord>,
+        time: DateTime,
     },
     LastMatch(Match),
     Received(Received),
@@ -117,6 +118,7 @@ pub enum Level2 {
     L2update {
         product_id: String,
         changes: Vec<Level2UpdateRecord>,
+        time: DateTime,
     },
 }
 
@@ -125,6 +127,13 @@ impl Level2 {
         match self {
             Level2::Snapshot { product_id, .. } => product_id,
             Level2::L2update { product_id, .. } => product_id,
+        }
+    }
+
+    pub fn time(&self) -> Option<&DateTime> {
+        match self {
+            Level2::Snapshot { .. } => None,
+            Level2::L2update { time, .. } => Some(time),
         }
     }
 }
@@ -481,9 +490,11 @@ impl From<InputMessage> for Message {
             InputMessage::L2update {
                 product_id,
                 changes,
+                time,
             } => Message::Level2(Level2::L2update {
                 product_id,
                 changes,
+                time,
             }),
             InputMessage::LastMatch(_match) => Message::Match(_match),
             InputMessage::Received(_match) => Message::Full(Full::Received(_match)),


### PR DESCRIPTION
Adding support for the `time` property of `l2update` messages.  Here is the sample message from the Coinbase Pro docs:

```json
  {
    "type": "l2update",
    "product_id": "BTC-USD",
    "time": "2019-08-14T20:42:27.265Z",
    "changes": [
      [
        "buy",
        "10101.80000000",
        "0.162567"
      ]
    ]
  }
  ```