### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ latency-tests = []
 [dependencies]
 async-trait = "0.1.42"
 base64 = "0.13.0"
-bytes = "1.0.1"
 chrono = { version = "0.4.9", features = [ "serde" ] }
 futures = { version = "0.3.8" }
 futures-util = { version = "0.3.8", features = ["compat"] }
@@ -24,16 +23,15 @@ hmac = "0.10.1"
 hyper = { version = "0.14.2", features = ["stream", "client", "http1"] }
 hyper-tls = "0.5.0"
 log = "0.4.4"
-pretty_env_logger = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.2"
 thiserror = "1.0.22"
-time = "0.2.24"
 tokio = { version = "1.0.2", features = ["full"] }
 tokio-tungstenite = { version = "0.13.0", features = ["tls"] }
 url = "2.1.0"
 uuid = { version = "0.8.1", features = [ "serde", "v4" ] }
 
 [dev-dependencies]
+#pretty_env_logger = "0.4.0"
 serial_test = "0.5.1"


### PR DESCRIPTION
`pretty-env-logger` has some (commented) uses in tests, so I moved it to `[dev-dependencies]` (and commented it).