### PR TITLE
Fix warning for deprecated keep_alive hyper method

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -80,10 +80,11 @@ impl<A> Public<A> {
     where
         A: AdapterNew,
     {
+        let max_idle = if keep_alive { std::usize::MAX } else { 0 };
+
         let https = HttpsConnector::new();
         let client = Client::builder()
-            // Keep this for now
-            .keep_alive(keep_alive)
+            .pool_max_idle_per_host(max_idle)
             .build::<_, Body>(https);
         let uri = uri.to_string();
 


### PR DESCRIPTION
Change-Id: Ie0fcafa28d14e3c004258878d84e0e472514c483

just replacing the deprecated method by the one recommended in the hyper doc.