### PR TITLE
Add 'ticker batch' channel type

### DIFF
--- a/src/structs/wsfeed.rs
+++ b/src/structs/wsfeed.rs
@@ -45,6 +45,8 @@ pub enum ChannelType {
     Heartbeat,
     Status,
     Ticker,
+    #[serde(rename = "ticker_1000")]
+    TickerBatch,
     Level2,
     Matches,
     Full,
@@ -66,9 +68,10 @@ pub(crate) enum InputMessage {
     },
     Status {
         products: Vec<StatusProduct>,
-        currencies: Vec<StatusCurrency>
+        currencies: Vec<StatusCurrency>,
     },
     Ticker(Ticker),
+    TickerBatch(Ticker),
     Snapshot {
         product_id: String,
         bids: Vec<Level2SnapshotRecord>,
@@ -105,9 +108,10 @@ pub enum Message {
     },
     Status {
         products: Vec<StatusProduct>,
-        currencies: Vec<StatusCurrency>
+        currencies: Vec<StatusCurrency>,
     },
     Ticker(Ticker),
+    TickerBatch(Ticker),
     Level2(Level2),
     Match(Match),
     Full(Full),
@@ -164,7 +168,7 @@ pub struct StatusProduct {
     pub post_only: bool,
     pub limit_only: bool,
     pub cancel_only: bool,
-    pub fx_stablecoin: bool
+    pub fx_stablecoin: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -520,6 +524,7 @@ impl From<InputMessage> for Message {
                 time,
             },
             InputMessage::Ticker(ticker) => Message::Ticker(ticker),
+            InputMessage::TickerBatch(ticker) => Message::TickerBatch(ticker),
             InputMessage::Snapshot {
                 product_id,
                 bids,
@@ -540,10 +545,10 @@ impl From<InputMessage> for Message {
             }),
             InputMessage::Status {
                 currencies,
-                products
+                products,
             } => Message::Status {
                 currencies,
-                products
+                products,
             },
             InputMessage::LastMatch(_match) => Message::Match(_match),
             InputMessage::Received(_match) => Message::Full(Full::Received(_match)),

--- a/src/wsfeed.rs
+++ b/src/wsfeed.rs
@@ -329,6 +329,32 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_ticker_batch() {
+        delay();
+        let found = Arc::new(AtomicBool::new(false));
+        let found2 = found.clone();
+
+        // hard to check in sandbox because low flow
+        let stream = WSFeed::connect(WS_URL, &["BTC-USD"], &[ChannelType::TickerBatch])
+            .await
+            .unwrap();
+        stream
+            .take(3)
+            .try_for_each(move |msg| {
+                let str = format!("{:?}", msg);
+                if str.contains("Ticker(Full { trade_id: ") {
+                    found2.swap(true, Ordering::Relaxed);
+                }
+                future::ready(Ok(()))
+            })
+            .await
+            .unwrap();
+
+        assert!(found.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_level2() {
         delay();
         let found_snapshot = Arc::new(AtomicBool::new(false));

--- a/src/wsfeed.rs
+++ b/src/wsfeed.rs
@@ -66,6 +66,7 @@ impl WSFeed {
             .map_err(|e| CBError::Websocket(WSError::Read(e)));
 
         let subscribe = serde_json::to_string(&subscribe).unwrap();
+
         stream.send(TMessage::Text(subscribe)).await?;
         log::debug!("subsription sent");
 
@@ -206,7 +207,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .take(2 )
+            .take(2)
             .try_for_each(|msg| {
                 println!("{:?}", msg);
                 let str = format!("{:?}", msg);


### PR DESCRIPTION
The [Coinbase docs reference a ticker_batch channel](https://docs.cloud.coinbase.com/exchange/docs/websocket-channels#ticker-batch-channel) which to date isn't supported by this library.

I've added support for it along with a passing test (FYI `cargo test` is failing).

To check the test I recommend running `cargo test test_ticker_batch`.